### PR TITLE
There is minimumTouchLengthToChangePage property which not used correctly

### DIFF
--- a/Extensions/CCScrollLayer/CCScrollLayer.h
+++ b/Extensions/CCScrollLayer/CCScrollLayer.h
@@ -90,6 +90,9 @@
 	
 	// Holds current pages width offset.
 	CGFloat pagesWidthOffset_;
+	
+	// Holds current margin offset
+	CGFloat marginOffset_;
 }
 
 @property (readwrite, retain) NSObject <CCScrollLayerDelegate> *delegate;
@@ -105,6 +108,9 @@
  * the page, without snapping back to the previous selected page.
  */
 @property(readwrite, assign) CGFloat minimumTouchLengthToChangePage;
+
+/** Offset that can be used to let user see empty space over first or last page. */
+@property(readwrite, assign) CGFloat  marginOffset;
 
 /** If YES - when starting scrolling CCScrollLayer will claim touches, that are 
  * already claimed by others targetedTouchDelegates by calling CCTouchDispatcher#touchesCancelled

--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -383,7 +383,7 @@ enum
 	
 	if (state_ == kCCScrollLayerStateSliding)
 	{
-		CGFloat desiredX = (- currentScreen_ * (self.contentSize.width - self.pagesWidthOffset)) + offset;
+		CGFloat desiredX = (- currentScreen_ * (self.contentSize.width - self.pagesWidthOffset)) + touchPoint.x - startSwipe_;
 		int page = [self pageNumberForPosition:ccp(desiredX, 0)];
 		CGFloat offset = desiredX - [self positionForPageWithNumber:page].x; 
 		if ((page == 0 && offset > 0) || (page == [layers_ count] - 1 && offset < 0))

--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -61,6 +61,7 @@ enum
 @synthesize delegate = delegate_;
 @synthesize minimumTouchLengthToSlide = minimumTouchLengthToSlide_;
 @synthesize minimumTouchLengthToChangePage = minimumTouchLengthToChangePage_;
+@synthesize marginOffset = marginOffset_;
 @synthesize currentScreen = currentScreen_;
 @synthesize showPagesIndicator = showPagesIndicator_;
 @synthesize pagesIndicatorPosition = pagesIndicatorPosition_;
@@ -97,6 +98,8 @@ enum
 		// Set default minimum touch length to scroll.
 		self.minimumTouchLengthToSlide = 30.0f;
 		self.minimumTouchLengthToChangePage = 100.0f;
+		
+		self.marginOffset = 50.0f;
 		
 		// Show indicator by default.
 		self.showPagesIndicator = YES;
@@ -379,33 +382,37 @@ enum
 	}
 	
 	if (state_ == kCCScrollLayerStateSliding)
-		self.position = ccp( (- currentScreen_ * (self.contentSize.width - self.pagesWidthOffset)) + (touchPoint.x-startSwipe_),0);	
-	
+	{
+		CGFloat offset = touchPoint.x - startSwipe_;
+		if ((currentScreen_ == 0 && offset > 0) || (currentScreen_ == [layers_ count] - 1 && offset < 0))
+			offset = marginOffset_ * offset / [[CCDirector sharedDirector] winSize].width;
+		self.position = ccp( (- currentScreen_ * (self.contentSize.width - self.pagesWidthOffset)) + offset, 0);
+	}
 }
 
 - (void)ccTouchEnded:(UITouch *)touch withEvent:(UIEvent *)event
 {
-	if( scrollTouch_ == touch ) {
-		scrollTouch_ = nil;
-	}
+	if( scrollTouch_ != touch )
+		return;
+	scrollTouch_ = nil;
 	
 	CGPoint touchPoint = [touch locationInView:[touch view]];
 	touchPoint = [[CCDirector sharedDirector] convertToGL:touchPoint];
 	
-	int newX = touchPoint.x;	
-	
-	if ( (newX - startSwipe_) < -self.minimumTouchLengthToChangePage && (currentScreen_+1) < [layers_ count] )
-	{		
-		[self moveToPage: [self pageNumberForPosition:self.position] ];		
+	int selectedPage = currentScreen_;
+	CGFloat delta = touchPoint.x - startSwipe_;
+	if (fabs(delta) >= m_fMinimumTouchLengthToChangePage)
+	{
+		selectedPage = [self pageNumberForPosition:self.position];
+		if (selectedPage == currentScreen_)
+		{
+			if (delta < 0.f && selectedPage < [layers_ count] - 1)
+				selectedPage++;
+			else if (delta > 0.f && selectedPage > 0)
+				selectedPage--;
+		}
 	}
-	else if ( (newX - startSwipe_) > self.minimumTouchLengthToChangePage && currentScreen_ > 0 )
-	{		
-		[self moveToPage: [self pageNumberForPosition:self.position] ];		
-	}
-	else
-	{		
-		[self moveToPage:currentScreen_];		
-	}	
+	[self moveToPage:selectedPage];	
 }
 
 #endif

--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -99,7 +99,7 @@ enum
 		self.minimumTouchLengthToSlide = 30.0f;
 		self.minimumTouchLengthToChangePage = 100.0f;
 		
-		self.marginOffset = 50.0f;
+		self.marginOffset = [[CCDirector sharedDirector] winSize].width;
 		
 		// Show indicator by default.
 		self.showPagesIndicator = YES;
@@ -383,10 +383,14 @@ enum
 	
 	if (state_ == kCCScrollLayerStateSliding)
 	{
-		CGFloat offset = touchPoint.x - startSwipe_;
-		if ((currentScreen_ == 0 && offset > 0) || (currentScreen_ == [layers_ count] - 1 && offset < 0))
-			offset = marginOffset_ * offset / [[CCDirector sharedDirector] winSize].width;
-		self.position = ccp( (- currentScreen_ * (self.contentSize.width - self.pagesWidthOffset)) + offset, 0);
+		CGFloat desiredX = (- currentScreen_ * (self.contentSize.width - self.pagesWidthOffset)) + offset;
+		int page = [self pageNumberForPosition:ccp(desiredX, 0)];
+		CGFloat offset = desiredX - [self positionForPageWithNumber:page].x; 
+		if ((page == 0 && offset > 0) || (page == [layers_ count] - 1 && offset < 0))
+			offset -= marginOffset_ * offset / [[CCDirector sharedDirector] winSize].width;
+		else
+			offset = 0;
+		self.position = ccp(desiredX - offset, 0);
 	}
 }
 
@@ -401,7 +405,7 @@ enum
 	
 	int selectedPage = currentScreen_;
 	CGFloat delta = touchPoint.x - startSwipe_;
-	if (fabs(delta) >= m_fMinimumTouchLengthToChangePage)
+	if (fabsf(delta) >= self.minimumTouchLengthToChangePage)
 	{
 		selectedPage = [self pageNumberForPosition:self.position];
 		if (selectedPage == currentScreen_)


### PR DESCRIPTION
There is minimumTouchLengthToChangePage property which not used correctly. Now scrolllayer use it and works as expected.

Also changed behavior when user trying to slide over first or last page. There is no need to show him empty screen. I've added marginOffset property which determine maximum margin offset which user can achieve when slide pages.

Please check code, i'm just convert my contribution to cocos2d-x version of this class.
