### PR TITLE
Fixes a bug where bottomToTop hides first element

### DIFF
--- a/Extensions/CCMenuAdvanced/CCMenuAdvanced.m
+++ b/Extensions/CCMenuAdvanced/CCMenuAdvanced.m
@@ -241,10 +241,13 @@
 	
 	CCARRAY_FOREACH(children_, item) {
 		CGSize itemSize = item.contentSize;
+		// need to start y higher, otherwise the first element will be hidden from view
+		if (bottomToTop)
+			y += itemSize.height * item.scaleY;
 	    [item setPosition:ccp(width / 2.0f, y - itemSize.height * item.scaleY / 2.0f)];
 		
 		if (bottomToTop)
-			y += itemSize.height * item.scaleY + padding;
+			y += padding;
 		else 
 			y -= itemSize.height * item.scaleY + padding;
 	}


### PR DESCRIPTION
Fixes a bug where bottomToTop elements essentially hide the first menu item from the bounding box.

If y were 0, the first item's position would be y = -h/2. With an anchor point of (0.5,0.5), the first element would be completely hidden.
