### PR TITLE
Added playMovieAtPath: 

### DIFF
--- a/Extensions/CCVideoPlayer/CCVideoPlayer.h
+++ b/Extensions/CCVideoPlayer/CCVideoPlayer.h
@@ -56,6 +56,10 @@
 
 #pragma mark Playback
 
+/** Start playing movie at given exact path, including extension
+ */
++ (void) playMovieAtPath: (NSString *) path;
+
 /** Start playing movie with given filename
  */
 + (void) playMovieWithFile: (NSString *) file;


### PR DESCRIPTION
I had a problem playing files in the simulator (5.1) and on long paths with a '.' in it, as playMovieWithResourceFile splits the file path around the first '.'. So I added a new method that foregoes type and bundle checks and plays movie at an exact (full) path. Now you can also play movies from the Documents folder if you download them there.
