### PR TITLE
Fix issue #108

### DIFF
--- a/Extensions/CCLayerPanZoom/CCLayerPanZoom.h
+++ b/Extensions/CCLayerPanZoom/CCLayerPanZoom.h
@@ -99,6 +99,8 @@ typedef enum
     CGFloat _rubberEffectRatio;
     BOOL _rubberEffectRecovering;
     BOOL _rubberEffectZooming;
+    
+    BOOL _isTouchBeganCalled;
 }
 
 #pragma mark Zoom Options

--- a/Extensions/CCLayerPanZoom/CCLayerPanZoom.h
+++ b/Extensions/CCLayerPanZoom/CCLayerPanZoom.h
@@ -99,8 +99,6 @@ typedef enum
     CGFloat _rubberEffectRatio;
     BOOL _rubberEffectRecovering;
     BOOL _rubberEffectZooming;
-    
-    BOOL _isTouchBeganCalled;
 }
 
 #pragma mark Zoom Options

--- a/Extensions/CCLayerPanZoom/CCLayerPanZoom.m
+++ b/Extensions/CCLayerPanZoom/CCLayerPanZoom.m
@@ -211,8 +211,6 @@ typedef enum
         self.rubberEffectRecoveryTime = 0.2f;
         _rubberEffectRecovering = NO;
         _rubberEffectZooming = NO;
-        
-        _isTouchBeganCalled = NO;
 	}	
 	return self;
 }
@@ -222,8 +220,6 @@ typedef enum
 - (void) ccTouchesBegan: (NSSet *) touches 
 			  withEvent: (UIEvent *) event
 {
-	_isTouchBeganCalled = YES;
-	
 	for (UITouch *touch in [touches allObjects]) 
 	{
 		// Add new touche to the array with current touches
@@ -247,7 +243,7 @@ typedef enum
 	// However, when the scene is transitioning in, ccTouchesBegan is not called,
 	// causing self.touches to be empty, thus crashing the app due to an attempt
 	// to access an empty array.
-	if (!_isTouchBeganCalled) return;
+	if ([self.touches count] == 0) return;
 	
 	BOOL multitouch = [self.touches count] > 1;
 	if (multitouch)
@@ -328,8 +324,6 @@ typedef enum
 - (void) ccTouchesEnded: (NSSet *) touches 
 			  withEvent: (UIEvent *) event
 {
-	_isTouchBeganCalled = NO;
-	
     _singleTouchTimestamp = INFINITY;
     
     // Process click event in single touch.
@@ -362,8 +356,6 @@ typedef enum
 - (void) ccTouchesCancelled: (NSSet *) touches 
 				  withEvent: (UIEvent *) event
 {
-	_isTouchBeganCalled = NO;
-	
 	for (UITouch *touch in [touches allObjects]) 
 	{
 		// Remove touche from the array with current touches


### PR DESCRIPTION
When the scene is transitioning in, if the user touches on the screen, ccTouchesBegan is not called, but ccTouchesMoved is called. This causes a NSRangeException to be thrown, because _touches is empty. I added a simple workaround to ensure that ccTouchesMoved will never get called unless ccTouchesBegan is called first.
