### PR TITLE
Code fix: Page Indicators won't be drawn if layer is not visible.

### DIFF
--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -163,6 +163,10 @@ enum
 
 - (void) visit
 {
+	 if (!visible_) //quick return in case not visible - make sure pages indicators don't show
+		return;
+    
+
 	[super visit];//< Will draw after glPopScene. 
 	
 	if (self.showPagesIndicator)


### PR DESCRIPTION
Modified visit method to quick return if the ScrollLayer is not set to visible. This fixes the bug where the Page Indicators would get drawn even if the layer was not visible.
