### PR TITLE
Fix a bug: Crash if other layer swallow the touch

### DIFF
--- a/Extensions/CCLayerPanZoom/CCLayerPanZoom.m
+++ b/Extensions/CCLayerPanZoom/CCLayerPanZoom.m
@@ -283,7 +283,7 @@ typedef enum
         // Don't click with multitouch
 		self.touchDistance = INFINITY;
 	}
-	else
+	else if ([self.touches count] == 1)
 	{	        
         // Get the single touch and it's previous & current position.
         UITouch *touch = [self.touches objectAtIndex: 0];


### PR DESCRIPTION
If other layer swallow the touch, [self.touches count] will equals 0. Then line 289 will cause a crash.
