### PR TITLE
When claiming touch do it in an orderly fashion

### DIFF
--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -356,6 +356,7 @@ enum
 #else
     CCTouchDispatcher *dispatcher = [CCTouchDispatcher sharedDispatcher];
 #endif
+	// First claim the touch and then cancel it on other handlers
     
 	// Enumerate through all targeted handlers.
 	for ( CCTargetedTouchHandler *handler in [dispatcher targetedHandlers] )
@@ -368,18 +369,24 @@ enum
 				[handler.claimedTouches addObject: aTouch];
 			}
 		}
-        else 
-        {
-            // Steal touch from other targeted delegates, if they claimed it.
-            if ([handler.claimedTouches containsObject: aTouch])
-            {
-                if ([handler.delegate respondsToSelector:@selector(ccTouchCancelled:withEvent:)])
-                {
-                    [handler.delegate ccTouchCancelled: aTouch withEvent: nil];
-                }
-                [handler.claimedTouches removeObject: aTouch];
-            }
-        }
+	}
+
+	// Enumerate through all targeted handlers.
+	for ( CCTargetedTouchHandler *handler in [dispatcher targetedHandlers] )
+	{
+		// The rest of the handlers.
+		if (handler.delegate != self)
+		{
+			// Steal touch from other targeted delegates, if they claimed it.
+			if ([handler.claimedTouches containsObject: aTouch])
+			{
+				if ([handler.delegate respondsToSelector:@selector(ccTouchCancelled:withEvent:)])
+				{
+					[handler.delegate ccTouchCancelled: aTouch withEvent: nil];
+				}
+				[handler.claimedTouches removeObject: aTouch];
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
First let the handler claim it, then cancel it on the rest of the handlers.

I came across a bug when a hade a handler that worked as a proxy handler.
CCScrollLayer looped through the handlers and claimed/cancelled without any order, the bug was when it first sent cancel to the proxy handler which in turn checked for all the "subhandlers" it proxies events too that subhandler hasn't claimed the touch then cancel. And because the claim wasn't made first, the proxy handler cancelled the event on all subhandlers, which then ended up in a crash.
