### PR TITLE
FilesDownloader: Downloaded file is corrupted if there is a duplicate entry

### DIFF
--- a/Extensions/FilesDownloader/FilesDownloader.m
+++ b/Extensions/FilesDownloader/FilesDownloader.m
@@ -63,7 +63,8 @@
 		_status = kDownloadStatusIdle;
 		
         // prepare size checkers
-        _filenames = [ files retain];
+        NSArray *uniqueFiles = [[NSSet setWithArray:files] allObjects];
+        _filenames = [ uniqueFiles retain];
 		self.sourcePath = aSourcePath;
         _fileSizes = [ [ NSMutableArray arrayWithCapacity: [_filenames count] ] retain];
         for ( int i = 0; i < [_filenames count]; ++i )


### PR DESCRIPTION
If the same file path is added twice to the same FilesDownloader instance, the first one will begin to download and add data to the .tmp file, then the second will begin to download with the same .tmp filename, and corrupt the first one. This was fixed by stripping out duplicates, which are obviously not needed.
