### PR TITLE
Remove redundant retina scale multiplier in CCScrollLayer

### DIFF
--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -183,7 +183,7 @@ enum
 		// Set GL Values
 #if COCOS2D_VERSION >= 0x00020000
         ccGLEnable(CC_GL_BLEND);
-        ccPointSize( 6.0 * CC_CONTENT_SCALE_FACTOR() );
+        ccPointSize( 6.0 );
 #define DRAW_4B_FUNC ccDrawColor4B
         
 #else
@@ -196,7 +196,7 @@ enum
         int blend_dst = 0;
         glGetIntegerv( GL_BLEND_SRC, &blend_src );
         glGetIntegerv( GL_BLEND_DST, &blend_dst );
-        glPointSize( 6.0 * CC_CONTENT_SCALE_FACTOR() );
+        glPointSize( 6.0 );
         
 #define DRAW_4B_FUNC glColor4ub        
 

--- a/Extensions/CCScrollLayer/CCScrollLayer.m
+++ b/Extensions/CCScrollLayer/CCScrollLayer.m
@@ -196,7 +196,7 @@ enum
         int blend_dst = 0;
         glGetIntegerv( GL_BLEND_SRC, &blend_src );
         glGetIntegerv( GL_BLEND_DST, &blend_dst );
-        glPointSize( 6.0 );
+        glPointSize( 6.0 * CC_CONTENT_SCALE_FACTOR() );
         
 #define DRAW_4B_FUNC glColor4ub        
 


### PR DESCRIPTION
For retina displays, the page indicators of CCScrollLayer are doubled in size. This has been verified with cocos2d 2.0.

For cocos2d 2.0, the point size is already multiplied with CC_CONTENT_SCALE_FACTOR by ccPointSize().

I did not test this change with cocos2d 1.0, but assume that the point size should be 6 (not 12) for a point distance of 16.
